### PR TITLE
add a parser for dockerignore files

### DIFF
--- a/dockerignore/dockerignore.go
+++ b/dockerignore/dockerignore.go
@@ -1,0 +1,22 @@
+package dockerignore
+
+import (
+	"bufio"
+	"io"
+)
+
+func Parse(r io.Reader) (ignores []string, err error) {
+	scan := bufio.NewScanner(r)
+
+	for scan.Scan() {
+		line := scan.Text()
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+
+		ignores = append(ignores, line)
+	}
+
+	err = scan.Err()
+	return
+}

--- a/dockerignore/dockerignore_test.go
+++ b/dockerignore/dockerignore_test.go
@@ -1,0 +1,53 @@
+package dockerignore
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	suite := []struct{
+		content string
+		expect []string
+	}{
+		{
+			content: "",
+			expect: []string{},
+		},
+		{
+			content: "\n",
+			expect: []string{},
+		},
+		{
+			content: "# foo\n",
+			expect: []string{},
+		},
+		{
+			content: "foo\n",
+			expect: []string{"foo"},
+		},
+		{
+			content: "# foo\nbar/\n",
+			expect: []string{"bar/"},
+		},
+		{
+			content: "# foo\n\n\nbar/\nbar\n\n",
+			expect: []string{"bar/", "bar"},
+		},
+	}
+
+	for _, test := range suite {
+		rdr := strings.NewReader(test.content)
+		ignores, err := Parse(rdr)
+		if err != nil {
+			t.Errorf("test %v unexpectedly fail: %v",
+				test.content, err)
+			continue
+		}
+		if slices.Compare(ignores, test.expect) != 0 {
+			t.Errorf("Unexpected result for %v; want %+v, got %+v",
+				test.content, test.expect, ignores)
+		}
+	}
+}

--- a/internal/parser/builder.go
+++ b/internal/parser/builder.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/containerd/platforms"
 	"github.com/google/go-jsonnet"
+	"github.com/jocker-org/jocker/dockerignore"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend/gateway/client"
@@ -103,6 +105,13 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 	j, err := ParseJockerfile(jsonStr)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(j.Excludes) == 0 {
+		content, err := readFile(ctx, c, ".dockerignore")
+		if err != nil {
+			j.Excludes, _ = dockerignore.Parse(bytes.NewReader(content))
+		}
 	}
 
 	state, err := j.ToLLB()


### PR DESCRIPTION
Initial implementation.  How do we want to deal with this?  A global function like this?

```
{
  // ...
  excludes: parseDockerignore(".dockerignore"),
}
```