### PR TITLE
feat: fix user and change default copy behaviour

### DIFF
--- a/Jockerfile
+++ b/Jockerfile
@@ -9,7 +9,7 @@ local std = import "std.libsonnet";
       "from": "alpine:latest",
       "steps": [
 	std.stage.step.workdir("/src"),
-	// {"type": "WORKDIR", "path": "/src"},
+	{"type": "WORKDIR", "path": "/src"},
         {"type": "RUN", "command": "apk update"},
         {"type": "RUN", "command": "apk upgrade"},
         {"type": "RUN", "command": "apk add mkdocs"},
@@ -22,10 +22,12 @@ local std = import "std.libsonnet";
       "name": "server",
       "from": "alpine:latest",
       "steps": [
+	{"type": "RUN", "command": "addgroup -g 1000 app && adduser -G app -u 1000 app -D"},
         {"type": "RUN", "command": "apk update"},
         {"type": "RUN", "command": "apk upgrade"},
         {"type": "RUN", "command": "apk add darkhttpd"},
         {"type": "COPY", "from": "builder", "src": "/src/site", "dst": "/www"},
+	{"type": "USER", "user": "1000"},
       ],
     },
   ],

--- a/Jockerfile
+++ b/Jockerfile
@@ -9,7 +9,7 @@ local std = import "std.libsonnet";
       "from": "alpine:latest",
       "steps": [
 	std.stage.step.workdir("/src"),
-	{"type": "WORKDIR", "path": "/src"},
+	// {"type": "WORKDIR", "path": "/src"},
         {"type": "RUN", "command": "apk update"},
         {"type": "RUN", "command": "apk upgrade"},
         {"type": "RUN", "command": "apk add mkdocs"},

--- a/internal/parser/jockerfile.go
+++ b/internal/parser/jockerfile.go
@@ -20,9 +20,13 @@ type WorkdirStep struct {
 	Path string `json:"path"`
 }
 
+type UserStep struct {
+	User string `json:"user"`
+}
+
 type BuildStage struct {
 	Name  string `json:"name"`
-	User  string `json:"user"`
+	// User  string `json:"user"`
 	From  string `json:"from"`
 	Steps *BuildSteps
 }
@@ -61,7 +65,9 @@ func (steps *BuildSteps) UnmarshalJSON(data []byte) error {
 			actual = &RunStep{}
 		case "WORKDIR":
 			actual = &WorkdirStep{}
-		}
+		case "USER":
+			actual = &UserStep{}
+		};
 		err = json.Unmarshal(r, actual)
 		if err != nil {
 			return err

--- a/internal/parser/jockerfile.go
+++ b/internal/parser/jockerfile.go
@@ -26,7 +26,6 @@ type UserStep struct {
 
 type BuildStage struct {
 	Name  string `json:"name"`
-	// User  string `json:"user"`
 	From  string `json:"from"`
 	Steps *BuildSteps
 }

--- a/lib/std.libsonnet
+++ b/lib/std.libsonnet
@@ -17,6 +17,7 @@
     step:: {
       workdir:: function(dir) {type: "WORKDIR", "path": dir},
       run:: function(cmd) {type: "RUN", "command": cmd},
+      user:: function(user) {type: "USER", "user": user},
       copy:: function(src, dst) {type:"COPY", src: src, dst: dst},
       copyFrom:: function(src, dst, from=null) {type:"COPY", from: from, src: src, dst: dst},
     },


### PR DESCRIPTION
Set User at step level instead of stage level.
In this way we can easily swap between users when necessary.

Also changed the default llb.Copy behaviour, which copy the entire directory to the destination, preserving the directory. This is in contrast on what the standard Dockerfile do, which copy the contents only